### PR TITLE
otp-jwtで二要素認証機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem "bootsnap", require: false
 gem 'devise'
 gem 'devise-i18n'
 
+gem 'otp-jwt'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jwt (2.8.1)
+      base64
     launchy (3.0.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -160,6 +162,10 @@ GEM
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    otp-jwt (0.3.1)
+      activesupport
+      jwt (~> 2)
+      rotp (~> 6)
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
@@ -213,6 +219,7 @@ GEM
       railties (>= 5.2)
     rexml (3.3.0)
       strscan
+    rotp (6.3.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -255,6 +262,7 @@ DEPENDENCIES
   jbuilder
   letter_opener_web
   mysql2 (~> 0.5)
+  otp-jwt
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   sprockets-rails

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -1,0 +1,19 @@
+class TwoFactorAuthenticationController < ApplicationController
+  def show
+    @user = User.find_by(two_factor_authentication_token: params[:two_factor_authentication_token])
+  end
+
+  def update
+    permit_parameters = params.permit(:user_id, :otp).to_h
+    user = User.find(permit_parameters[:user_id])
+
+    # OTPが正しければユーザーをサインイン、正しくなければ認証画面にリダイレクト
+    if user.verify_otp(permit_parameters[:otp]).present?
+      sign_in(user)
+      redirect_to root_path, notice: 'ログインしました'
+    else
+      flash[:alert] = '入力に誤りがあります。もう一度入力してください。'
+      redirect_to new_user_session_path
+    end
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,26 @@
+class Users::SessionsController < Devise::SessionsController
+  def new
+    super
+  end
+
+  def create
+    super do |resource|
+      # ログインに成功したら、ワンタイムパスワードを生成して、保存する
+      if resource.persisted?
+        resource.two_factor_authentication_token = SecureRandom.hex(20)
+        resource.save!
+        sign_out resource
+
+        # ログイン成功後にワンタイムパスワードが載ったメールを送信
+        resource.email_otp
+
+        # ワンタイムパスワードを入力できる認証画面に遷移
+        redirect_to two_factor_authentication_show_path(two_factor_authentication_token: resource.two_factor_authentication_token) and return
+      end
+    end
+  end
+
+  def destroy
+    super
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,14 @@
+require 'otp/mailer'
+
 class User < ApplicationRecord
+  include OTP::ActiveRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :trackable, :confirmable, :lockable, :timeoutable
+
+  def email_otp
+    OTP::Mailer.otp(email, otp, self).deliver_later
+  end
 end

--- a/app/views/two_factor_authentication/show.html.erb
+++ b/app/views/two_factor_authentication/show.html.erb
@@ -1,0 +1,11 @@
+<h2>二要素認証</h2>
+<%= form_with url: two_factor_authentication_update_path, method: :post do %>
+  <div class="field">
+    <input type="hidden" name="user_id" value="<%= @user.id %>" autocomplete="off">
+    <%= label_tag :otp, 'ワンタイムパスワード入力：' %>
+    <%= text_field_tag :otp %>
+  </div>
+  <div class="actions">
+    <%= submit_tag '送信' %>
+  </div>
+<% end %>

--- a/config/initializers/otp-jwt.rb
+++ b/config/initializers/otp-jwt.rb
@@ -1,0 +1,19 @@
+# config/initializers/otp-jwt.rb
+require 'otp'
+# To load the JWT related support.
+require 'otp/jwt'
+
+require 'otp/mailer'
+
+# Set to 'none' to disable verification at all.
+# OTP::JWT::Token.jwt_algorithm = 'HS256'
+
+# How long the token will be valid.
+# OTP::JWT::Token.jwt_lifetime = 60 * 60 * 24
+
+OTP::JWT::Token.jwt_signature_key = 'b001745e5437b15d1fc79160bd637abdfbe68361b8e1c3f1d26f224a82a128dcab95d7062d3dbe503ee80f772bf07f6e1c4480a3f80fe008245bcee1e58674a2'
+
+OTP::Mailer.default subject: 'Your App magic password'
+OTP::Mailer.default from: 'from@example.com'
+# Tell mailer to use the template from app/views/otp/mailer/otp.html.erb
+OTP::Mailer.prepend_view_path(Rails.root.join('app', 'views'))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { sessions: 'users/sessions' }
   get 'home/index'
   get 'home/show'
 
   root to: "home#index"
+
+  # 2FA機能
+  get 'two_factor_authentication/show', to: 'two_factor_authentication#show', as: :two_factor_authentication_show
+  post 'two_factor_authentication/update', to: 'two_factor_authentication#update', as: :two_factor_authentication_update
   
   ## 開発環境用letter_opener
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?

--- a/db/migrate/20240617004426_add_otp_to_users.rb
+++ b/db/migrate/20240617004426_add_otp_to_users.rb
@@ -1,0 +1,9 @@
+class AddOtpToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :two_factor_authentication_token, :string
+    add_column :users, :otp_secret, :string
+    add_column :users, :otp_counter, :integer
+
+    add_index :users, :two_factor_authentication_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_022021) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_004426) do
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -31,9 +31,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_022021) do
     t.datetime "locked_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "two_factor_authentication_token"
+    t.string "otp_secret"
+    t.integer "otp_counter"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["two_factor_authentication_token"], name: "index_users_on_two_factor_authentication_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 


### PR DESCRIPTION
- 関連 #1
- 二要素認証機能を追加

- otp-jwt で実装できる処理
OTPの生成
OTPが載ったメールの送信
入力されたOTPの認可処理
- 自前で作らないといけない処理
ログイン時に二要素認証画面に遷移するときにログアウトするように書かないといけない
二要素認証画面は自前で作成

