### PR TITLE
active-model-otpで二要素認証機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem "bootsnap", require: false
 gem 'devise'
 gem 'devise-i18n'
 
+# 2FA機能
+gem 'active_model_otp'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,9 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_model_otp (2.3.4)
+      activemodel
+      rotp (~> 6.3.0)
     activejob (7.1.3.4)
       activesupport (= 7.1.3.4)
       globalid (>= 0.3.6)
@@ -213,6 +216,7 @@ GEM
       railties (>= 5.2)
     rexml (3.3.0)
       strscan
+    rotp (6.3.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -248,6 +252,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_otp
   bootsnap
   debug
   devise

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -1,36 +1,19 @@
 class TwoFactorAuthenticationController < ApplicationController
-  before_action :validate_two_factor_session, only: [:show, :update]
-
   def show
-    @user = User.find(session[:two_factor_user_id])
+    @user = User.find(cookies[:two_factor_user_id])
   end
 
   def update
     permit_parameters = params.permit(:user_id, :otp).to_h
-    user = User.find(session[:two_factor_user_id])
+    user = User.find(cookies[:two_factor_user_id])
 
     # OTPが正しければユーザーをサインイン、正しくなければ認証画面にリダイレクト
     if user.authenticate_otp(permit_parameters[:otp], drift: 60)
       sign_in(user)
-      clear_two_factor_session
       redirect_to root_path, notice: 'ログインしました'
     else
       flash[:alert] = '入力に誤りがあります。もう一度入力してください。'
       redirect_to two_factor_authentication_show_path
     end
-  end
-
-  private
-
-  def validate_two_factor_session
-    if session[:two_factor_user_id].nil? || session[:two_factor_expires_at].nil? || session[:two_factor_expires_at] < Time.zone.now
-      clear_two_factor_session
-      redirect_to new_user_session_path, alert: 'セッションが無効です。再度ログインしてください'
-    end
-  end
-
-  def clear_two_factor_session
-    session.delete(:two_factor_user_id)
-    session.delete(:two_factor_expires_at)
   end
 end

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -1,11 +1,13 @@
 class TwoFactorAuthenticationController < ApplicationController
   def show
-    @user = User.find(cookies[:two_factor_user_id])
+    user_id = current_user.id
+    sign_out current_user
+    @user = User.find(user_id)
   end
 
   def update
     permit_parameters = params.permit(:user_id, :otp).to_h
-    user = User.find(cookies[:two_factor_user_id])
+    user = User.find(permit_parameters[:user_id])
 
     # OTPが正しければユーザーをサインイン、正しくなければ認証画面にリダイレクト
     if user.authenticate_otp(permit_parameters[:otp], drift: 60)

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -1,0 +1,19 @@
+class TwoFactorAuthenticationController < ApplicationController
+  def show
+    @user = User.find_by(two_factor_authentication_token: params[:two_factor_authentication_token])
+  end
+
+  def update
+    permit_parameters = params.permit(:user_id, :otp).to_h
+    user = User.find(permit_parameters[:user_id])
+
+    # OTPが正しければユーザーをサインイン、正しくなければ認証画面にリダイレクト
+    if user.authenticate_otp(params[:otp])
+      sign_in(user)
+      redirect_to root_path, notice: 'ログインしました'
+    else
+      flash[:alert] = '入力に誤りがあります。もう一度入力してください。'
+      redirect_to two_factor_authentication_show_path(two_factor_authentication_token: user.two_factor_authentication_token)
+    end
+  end
+end

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -8,7 +8,7 @@ class TwoFactorAuthenticationController < ApplicationController
     user = User.find(permit_parameters[:user_id])
 
     # OTPが正しければユーザーをサインイン、正しくなければ認証画面にリダイレクト
-    if user.authenticate_otp(params[:otp])
+    if user.authenticate_otp(params[:otp], drift: 60)
       sign_in(user)
       redirect_to root_path, notice: 'ログインしました'
     else

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -1,8 +1,5 @@
 class TwoFactorAuthenticationController < ApplicationController
   def show
-    user_id = current_user.id
-    sign_out current_user
-    @user = User.find(user_id)
   end
 
   def update

--- a/app/controllers/two_factor_authentication_controller.rb
+++ b/app/controllers/two_factor_authentication_controller.rb
@@ -1,19 +1,36 @@
 class TwoFactorAuthenticationController < ApplicationController
+  before_action :validate_two_factor_session, only: [:show, :update]
+
   def show
-    @user = User.find_by(two_factor_authentication_token: params[:two_factor_authentication_token])
+    @user = User.find(session[:two_factor_user_id])
   end
 
   def update
     permit_parameters = params.permit(:user_id, :otp).to_h
-    user = User.find(permit_parameters[:user_id])
+    user = User.find(session[:two_factor_user_id])
 
     # OTPが正しければユーザーをサインイン、正しくなければ認証画面にリダイレクト
-    if user.authenticate_otp(params[:otp], drift: 60)
+    if user.authenticate_otp(permit_parameters[:otp], drift: 60)
       sign_in(user)
+      clear_two_factor_session
       redirect_to root_path, notice: 'ログインしました'
     else
       flash[:alert] = '入力に誤りがあります。もう一度入力してください。'
-      redirect_to two_factor_authentication_show_path(two_factor_authentication_token: user.two_factor_authentication_token)
+      redirect_to two_factor_authentication_show_path
     end
+  end
+
+  private
+
+  def validate_two_factor_session
+    if session[:two_factor_user_id].nil? || session[:two_factor_expires_at].nil? || session[:two_factor_expires_at] < Time.zone.now
+      clear_two_factor_session
+      redirect_to new_user_session_path, alert: 'セッションが無効です。再度ログインしてください'
+    end
+  end
+
+  def clear_two_factor_session
+    session.delete(:two_factor_user_id)
+    session.delete(:two_factor_expires_at)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+class Users::SessionsController < Devise::SessionsController
+  def new
+    super
+  end
+
+  def create
+    super do |resource|
+      # ログインに成功したら、ワンタイムパスワードを生成して、保存する
+      if resource.persisted?
+        resource.two_factor_authentication_token = SecureRandom.hex(20)
+        resource.save!
+        sign_out resource
+
+        # ログイン成功後にワンタイムパスワード画面にメールを送信
+        otp = resource.otp_code
+        UserMailer.otp_email(resource, otp).deliver_now
+
+        # ワンタイムパスワードを入力できる認証画面に遷移
+        redirect_to two_factor_authentication_show_path(two_factor_authentication_token: resource.two_factor_authentication_token) and return
+      end
+    end
+  end
+
+  def destroy
+    super
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,10 +7,10 @@ class Users::SessionsController < Devise::SessionsController
     super do |resource|
       # ログインに成功したら、ワンタイムパスワードを生成して、保存する
       if resource.persisted?
-        resource.two_factor_authentication_token = SecureRandom.hex(20)
-        resource.save!
-        session[:two_factor_user_id] = resource.id
-        session[:two_factor_expires_at] = 3.minutes.from_now
+        cookies[:two_factor_user_id] = {
+          value: resource.id,
+          expires: 3.minutes.from_now
+        }
         sign_out resource
 
         # ログイン成功後にワンタイムパスワード画面にメールを送信

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,12 +7,6 @@ class Users::SessionsController < Devise::SessionsController
     super do |resource|
       # ログインに成功したら、ワンタイムパスワードを生成して、保存する
       if resource.persisted?
-        cookies[:two_factor_user_id] = {
-          value: resource.id,
-          expires: 3.minutes.from_now
-        }
-        sign_out resource
-
         # ログイン成功後にワンタイムパスワード画面にメールを送信
         otp = resource.otp_code
         UserMailer.otp_email(resource, otp).deliver_now

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,6 +9,8 @@ class Users::SessionsController < Devise::SessionsController
       if resource.persisted?
         resource.two_factor_authentication_token = SecureRandom.hex(20)
         resource.save!
+        session[:two_factor_user_id] = resource.id
+        session[:two_factor_expires_at] = 3.minutes.from_now
         sign_out resource
 
         # ログイン成功後にワンタイムパスワード画面にメールを送信
@@ -16,7 +18,7 @@ class Users::SessionsController < Devise::SessionsController
         UserMailer.otp_email(resource, otp).deliver_now
 
         # ワンタイムパスワードを入力できる認証画面に遷移
-        redirect_to two_factor_authentication_show_path(two_factor_authentication_token: resource.two_factor_authentication_token) and return
+        redirect_to two_factor_authentication_show_path and return
       end
     end
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,9 +10,11 @@ class Users::SessionsController < Devise::SessionsController
         # ログイン成功後にワンタイムパスワード画面にメールを送信
         otp = resource.otp_code
         UserMailer.otp_email(resource, otp).deliver_now
+        sign_out current_user
 
         # ワンタイムパスワードを入力できる認証画面に遷移
-        redirect_to two_factor_authentication_show_path and return
+        redirect_to two_factor_authentication_show_path, flash: { user_id: resource.id }
+        return
       end
     end
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,7 @@
+class UserMailer < ApplicationMailer
+  def otp_email(user, otp)
+    @user = user
+    @otp = otp
+    mail(to: @user.email, subject: 'Your One-Time Password')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_one_time_password
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_one_time_password after_column_name: :last_otp_at
+  has_one_time_password after_column_name: :last_otp_at, backup_codes_count: 6, one_time_backup_codes: true
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_one_time_password
+  has_one_time_password after_column_name: :last_otp_at
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/two_factor_authentication/show.html.erb
+++ b/app/views/two_factor_authentication/show.html.erb
@@ -1,0 +1,11 @@
+<h2>二要素認証</h2>
+<%= form_with url: two_factor_authentication_update_path, method: :post do %>
+  <div class="field">
+    <input type="hidden" name="user_id" value="<%= @user.id %>" autocomplete="off">
+    <%= label_tag :otp, 'ワンタイムパスワード入力：' %>
+    <%= text_field_tag :otp %>
+  </div>
+  <div class="actions">
+    <%= submit_tag '送信' %>
+  </div>
+<% end %>

--- a/app/views/two_factor_authentication/show.html.erb
+++ b/app/views/two_factor_authentication/show.html.erb
@@ -1,7 +1,6 @@
 <h2>二要素認証</h2>
 <%= form_with url: two_factor_authentication_update_path, method: :post do %>
   <div class="field">
-    <input type="hidden" name="user_id" value="<%= @user.id %>" autocomplete="off">
     <%= label_tag :otp, 'ワンタイムパスワード入力：' %>
     <%= text_field_tag :otp %>
   </div>

--- a/app/views/two_factor_authentication/show.html.erb
+++ b/app/views/two_factor_authentication/show.html.erb
@@ -1,6 +1,7 @@
 <h2>二要素認証</h2>
 <%= form_with url: two_factor_authentication_update_path, method: :post do %>
   <div class="field">
+    <input type="hidden" name="user_id" value="<%= @user.id %>" autocomplete="off">
     <%= label_tag :otp, 'ワンタイムパスワード入力：' %>
     <%= text_field_tag :otp %>
   </div>

--- a/app/views/two_factor_authentication/show.html.erb
+++ b/app/views/two_factor_authentication/show.html.erb
@@ -1,7 +1,7 @@
 <h2>二要素認証</h2>
 <%= form_with url: two_factor_authentication_update_path, method: :post do %>
   <div class="field">
-    <input type="hidden" name="user_id" value="<%= @user.id %>" autocomplete="off">
+    <input type="hidden" name="user_id" value="<%= flash[:user_id] %>" autocomplete="off">
     <%= label_tag :otp, 'ワンタイムパスワード入力：' %>
     <%= text_field_tag :otp %>
   </div>

--- a/app/views/user_mailer/otp_email.html.erb
+++ b/app/views/user_mailer/otp_email.html.erb
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Your One-Time Password</h1>
+    <p>Hello, <%= @user.email %>!</p>
+    <p>Your one-time password is <strong><%= @otp %></strong>.</p>
+  </body>
+</html>

--- a/app/views/user_mailer/otp_email.text.erb
+++ b/app/views/user_mailer/otp_email.text.erb
@@ -1,0 +1,5 @@
+Your One-Time Password
+
+Hello, <%= @user.email %>!
+
+Your one-time password is <%= @otp %>.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { sessions: 'users/sessions' }
   get 'home/index'
   get 'home/show'
 
   root to: "home#index"
+
+  # 2FA機能
+  get 'two_factor_authentication/show', to: 'two_factor_authentication#show', as: :two_factor_authentication_show
+  post 'two_factor_authentication/update', to: 'two_factor_authentication#update', as: :two_factor_authentication_update
   
   ## 開発環境用letter_opener
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?

--- a/db/migrate/20240617024920_add_otp_secret_key_to_users.rb
+++ b/db/migrate/20240617024920_add_otp_secret_key_to_users.rb
@@ -3,6 +3,7 @@ class AddOtpSecretKeyToUsers < ActiveRecord::Migration[7.1]
     add_column :users, :two_factor_authentication_token, :string
     add_column :users, :otp_secret_key, :string
     add_column :users, :last_otp_at, :integer
+    add_column :users, :otp_backup_codes, :json
 
     add_index :users, :two_factor_authentication_token, unique: true
   end

--- a/db/migrate/20240617024920_add_otp_secret_key_to_users.rb
+++ b/db/migrate/20240617024920_add_otp_secret_key_to_users.rb
@@ -1,0 +1,8 @@
+class AddOtpSecretKeyToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :two_factor_authentication_token, :string
+    add_column :users, :otp_secret_key, :string
+
+    add_index :users, :two_factor_authentication_token, unique: true
+  end
+end

--- a/db/migrate/20240617024920_add_otp_secret_key_to_users.rb
+++ b/db/migrate/20240617024920_add_otp_secret_key_to_users.rb
@@ -1,10 +1,7 @@
 class AddOtpSecretKeyToUsers < ActiveRecord::Migration[7.1]
   def change
-    add_column :users, :two_factor_authentication_token, :string
     add_column :users, :otp_secret_key, :string
     add_column :users, :last_otp_at, :integer
     add_column :users, :otp_backup_codes, :json
-
-    add_index :users, :two_factor_authentication_token, unique: true
   end
 end

--- a/db/migrate/20240617024920_add_otp_secret_key_to_users.rb
+++ b/db/migrate/20240617024920_add_otp_secret_key_to_users.rb
@@ -2,6 +2,7 @@ class AddOtpSecretKeyToUsers < ActiveRecord::Migration[7.1]
   def change
     add_column :users, :two_factor_authentication_token, :string
     add_column :users, :otp_secret_key, :string
+    add_column :users, :last_otp_at, :integer
 
     add_index :users, :two_factor_authentication_token, unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_024920) do
     t.datetime "updated_at", null: false
     t.string "two_factor_authentication_token"
     t.string "otp_secret_key"
+    t.integer "last_otp_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_024920) do
     t.string "two_factor_authentication_token"
     t.string "otp_secret_key"
     t.integer "last_otp_at"
+    t.json "otp_backup_codes"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_022021) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_024920) do
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -31,9 +31,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_022021) do
     t.datetime "locked_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "two_factor_authentication_token"
+    t.string "otp_secret_key"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["two_factor_authentication_token"], name: "index_users_on_two_factor_authentication_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,14 +31,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_024920) do
     t.datetime "locked_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "two_factor_authentication_token"
     t.string "otp_secret_key"
     t.integer "last_otp_at"
     t.json "otp_backup_codes"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["two_factor_authentication_token"], name: "index_users_on_two_factor_authentication_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 


### PR DESCRIPTION
- 関連：#1 
- 二要素認証機能を追加

- active-model-otpで実装できる処理
OTPの生成
入力されたOTPの認可処理
- 自前で作らないといけない処理
ログイン時に二要素認証画面に遷移するときにログアウトするように書かないといけない
OTPが載ったメールの送信
二要素認証画面は自前で作成

### 良い箇所
ユーザモデルに`otp_counter`カラムなどの不必要なカラムを追加しない

### 気になる箇所
