### PR TITLE
two_factor_authenticationで二要素認証機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem "bootsnap", require: false
 gem 'devise'
 gem 'devise-i18n'
 
+# 2FA機能
+gem 'two_factor_authentication'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     devise-i18n (1.12.1)
       devise (>= 4.9.0)
     drb (2.2.1)
+    encryptor (3.0.0)
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -204,6 +205,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    randexp (0.1.7)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     reline (0.5.9)
@@ -213,6 +215,7 @@ GEM
       railties (>= 5.2)
     rexml (3.3.0)
       strscan
+    rotp (6.3.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -224,6 +227,12 @@ GEM
     strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
+    two_factor_authentication (2.2.0)
+      devise
+      encryptor
+      rails (>= 3.1.1)
+      randexp
+      rotp (>= 4.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
@@ -258,6 +267,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   sprockets-rails
+  two_factor_authentication
   tzinfo-data
   web-console
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :trackable, :confirmable, :lockable, :timeoutable
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable,
+         :validatable, :two_factor_authenticatable, :trackable, :confirmable,
+         :lockable, :timeoutable
+  has_one_time_password(encrypted: true)
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -20,6 +20,16 @@ Devise.setup do |config|
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'
 
+  config.max_login_attempts = 3  # Maximum second factor attempts count.
+  config.allowed_otp_drift_seconds = 30  # Allowed TOTP time drift between client and server.
+  config.otp_length = 6  # TOTP code length
+  config.direct_otp_valid_for = 5.minutes  # Time before direct OTP becomes invalid
+  config.direct_otp_length = 6  # Direct OTP code length
+  config.remember_otp_session_for_seconds = 30.days  # Time before browser has to perform 2fA again. Default is 0.
+  config.otp_secret_encryption_key = 'fbc512318120d748355fd872363a3155cf9e97936e5614053479c2b3965e3ebb8501496b33a5d3b97b4fa8f65f7b122efb07795dd64ec45351b1395545e706d5'
+  config.second_factor_resource_id = 'id' # Field or method name used to set value for 2fA remember cookie
+  config.delete_cookie_on_logout = false # Delete cookie when user signs out, to force 2fA again on login
+
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class

--- a/db/migrate/20240617054751_add_two_factor_fields_to_users.rb
+++ b/db/migrate/20240617054751_add_two_factor_fields_to_users.rb
@@ -1,0 +1,12 @@
+class AddTwoFactorFieldsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :second_factor_attempts_count, :integer
+    add_column :users, :encrypted_otp_secret_key, :string
+    add_index :users, :encrypted_otp_secret_key, unique: true
+    add_column :users, :encrypted_otp_secret_key_iv, :string
+    add_column :users, :encrypted_otp_secret_key_salt, :string
+    add_column :users, :direct_otp, :string
+    add_column :users, :direct_otp_sent_at, :datetime
+    add_column :users, :totp_timestamp, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_022021) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_054751) do
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -31,8 +31,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_022021) do
     t.datetime "locked_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "second_factor_attempts_count"
+    t.string "encrypted_otp_secret_key"
+    t.string "encrypted_otp_secret_key_iv"
+    t.string "encrypted_otp_secret_key_salt"
+    t.string "direct_otp"
+    t.datetime "direct_otp_sent_at"
+    t.timestamp "totp_timestamp"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end


### PR DESCRIPTION
- 関連：#1 
- 二要素認証機能を追加しようとしたが、ログインしようとエラーになる
このgemでの実装は困難だと考えるため、このgemは断念

## エラー内容
`two_factor_authentication `での二要素認証機能を追加した場合に以下のように`update_attributes`メソッドが見つからないというエラーになる。
`update_attributes`メソッドはRails 6.1から削除されているメソッドであるため、メソッドが見つからないようです。

ーーーーーーーーーーーーーーーーーー
<img width="1002" alt="image" src="https://github.com/zakino123/AuthenticationApp/assets/75520329/3b30161e-12c1-482f-8992-4525b31b9f58">
ーーーーーーーーーーーーーーーーーー

参考記事：https://railsguides.jp/6_1_release_notes.html#active-record-%E5%89%8A%E9%99%A4%E3%81%95%E3%82%8C%E3%81%9F%E3%82%82%E3%81%AE